### PR TITLE
ci: run on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  push:
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- run CI on push events as well as pull requests

## Testing
- `dotnet test` *(fails: Unable to load shared library 'libdl')*


------
https://chatgpt.com/codex/tasks/task_e_6897d1179b80832db057e61bf3bee8ed